### PR TITLE
Take advantage of `ICustomFormatter` or `IFormattable`

### DIFF
--- a/src/FsMessageTemplates/MessageTemplates.fs
+++ b/src/FsMessageTemplates/MessageTemplates.fs
@@ -490,7 +490,7 @@ module Destructure =
             DictionaryValue skvps
         | e -> SequenceValue(e |> Seq.cast<obj> |> Seq.map r.TryAgainWithValue |> Seq.toList)
 
-    let inline scalarStringCatchAllDestr (r:DestructureRequest) = ScalarValue (r.Value.ToString())
+    let inline scalarOriginCatchAllDestr (r:DestructureRequest) = ScalarValue (r.Value)
 
     let inline isPublicInstanceReadProp (p:PropertyInfo) =
         p.CanRead && p.GetMethod.IsPublic && not (p.GetMethod.IsStatic) &&
@@ -534,7 +534,7 @@ module Destructure =
     let inline alwaysKeepTrying (_:DestructureRequest) = TemplatePropertyValue.Empty
 
     /// Attempts all built-in destructurers in the correct order, falling
-    /// back to 'scalarStringCatchAllDestr' (stringify) if no better option
+    /// back to 'scalarOriginCatchAllDestr' (origin) if no better option
     /// is found first. Also supports custom scalars and custom object
     /// destructuring at the appropriate points in the pipline. Note this is
     /// called recursively in a tight loop during the process of capturing
@@ -559,7 +559,7 @@ module Destructure =
                                 | tpv when isEmptyKeepTrying tpv ->
                                     match tryObjectStructureDestructuring request with
                                     | tpv when isEmptyKeepTrying tpv ->
-                                        match scalarStringCatchAllDestr request with
+                                        match scalarOriginCatchAllDestr request with
                                         | tpv when isEmptyKeepTrying tpv -> TemplatePropertyValue.Empty
                                         | tpv -> tpv
                                     | tpv -> tpv


### PR DESCRIPTION
Change `scalarStringCatchAllDestr` to catch the original scalar object, then format properly when `writePropValue`.

e.g.

```fsharp
type User = 
  {
    id      : int 
    name    : string
    created : DateTime
  }
with
  interface IFormattable with
    member x.ToString (format, provider) =
      sprintf "id => %i, name => %s, created => %A" x.id x.name (x.created.ToShortDateString())

let foo = { id = 999; name = "foo"; created = DateTime.Now}
let nl = Environment.NewLine + Environment.NewLine

Formatting.format (Parser.parse "{default} {nl} {$stringify} {nl} {@capture}") [| foo; nl; foo; nl; foo; |] 
System.String.Format("{0}",foo)
```

before: 

```shell
> Formatting.format (Parser.parse "{default} {nl} {$stringify} {nl} {@capture}") [| foo; nl; foo; nl; foo; |]
- ;;
val it : string =
  ""{id = 999;
 name = \"foo\";
 created = 11/3/2017 7:49:41 PM;}" "

" "{id = 999;
 name = \"foo\";
 created = 11/3/2017 7:49:41 PM;}" "

" User { id: 999, name: "foo", created: 11/3/2017 7:49:41 PM }"

> System.String.Format("{0}",foo)
- ;;
val it : string = "id => 999, name => foo, created => "11/3/2017""
```

after:


```shell
> Formatting.format (Parser.parse "{default} {nl} {$stringify} {nl} {@capture}") [| foo; nl; foo; nl; foo; |]
val it : string =
  "id => 999, name => foo, created => "11/3/2017" "

" "{id = 999;
 name = \"foo\";
 created = 11/3/2017 7:40:16 PM;}" "

" User { id: 999, name: "foo", created: 11/3/2017 7:40:16 PM }"

> System.String.Format("{0}",foo)
val it : string = "id => 999, name => foo, created => "11/3/2017""
```


